### PR TITLE
Set userId on SignalR connection info

### DIFF
--- a/negotiate2/index.js
+++ b/negotiate2/index.js
@@ -12,6 +12,8 @@ module.exports = async function (context, req) {
   context.log(`🔐 Negotiating SignalR connection for userId: ${userId}`);
 
   const connectionInfo = context.bindings.signalRConnectionInfo;
+  connectionInfo.userId = userId;
+  
   try {
 
     context.log('✅ Negotiation success');


### PR DESCRIPTION
Assigns the userId to the connectionInfo object before negotiation, ensuring the user is correctly associated with the SignalR connection.